### PR TITLE
Register channel for plugin message system

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -262,6 +262,7 @@ public final class RedisBungee extends Plugin implements Listener {
                 }
             }, 1, 5, TimeUnit.MINUTES);
         }
+        ProxyServer.getInstance().registerChannel("RedisBungee");
     }
 
     @Override


### PR DESCRIPTION
The plugin message system can't work if the listened channel isn't registered.
