### PR TITLE
Fix compatibility with other server ping plugins.

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -22,6 +22,7 @@ import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.*;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
 import redis.clients.jedis.Jedis;
 
 import java.util.*;
@@ -57,15 +58,9 @@ public class RedisBungeeListener implements Listener {
         plugin.getConsumer().queue(new PlayerChangedServerConsumerEvent(event.getPlayer(), event.getServer().getInfo()));
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onPing(ProxyPingEvent event) {
-        ServerPing old = event.getResponse();
-        ServerPing reply = new ServerPing();
-        reply.setPlayers(new ServerPing.Players(old.getPlayers().getMax(), plugin.getCount(), old.getPlayers().getSample()));
-        reply.setDescription(old.getDescription());
-        reply.setFavicon(old.getFaviconObject());
-        reply.setVersion(old.getVersion());
-        event.setResponse(reply);
+        event.getResponse().getPlayers().setOnline(plugin.getCount());
     }
 
     @EventHandler


### PR DESCRIPTION
At the moment if RedisBungee is used with a plugin like [ServerListPlus](http://www.spigotmc.org/resources/serverlistplus.241/) then depending on the runtime environment it is possible that RedisBungee modifies the player count after the other plugins. If one of the other plugins uses the player count (for example: [custom player slots](https://github.com/Minecrell/ServerListPlus/wiki/Player-Slots)) then it will only use the player count of the current BungeeCord and not the combined one.

To fix that we can use an event handler with lower priority for the ping event so RedisBungee can modify the player count before all other plugins. I have also changed so the online count is modified directly and the response is not completely cloned - not exactly sure why you were doing this but I can revert this if you want to keep it.
