### PR TITLE
Add formerServer to PlayerChangedServerNetworkEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.imaginarycode.minecraft</groupId>
     <artifactId>RedisBungee</artifactId>
-    <version>0.3.5-SNAPSHOT</version>
+    <version>0.3.6-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/DataManager.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/DataManager.java
@@ -269,7 +269,7 @@ public class DataManager implements Listener {
                 plugin.getProxy().getScheduler().runAsync(plugin, new Runnable() {
                     @Override
                     public void run() {
-                        plugin.getProxy().getPluginManager().callEvent(new PlayerChangedServerNetworkEvent(message3.getTarget(), message3.getPayload().getServer()));
+                        plugin.getProxy().getPluginManager().callEvent(new PlayerChangedServerNetworkEvent(message3.getTarget(), message3.getPayload().getFormerServer(), message3.getPayload().getServer()));
                     }
                 });
                 break;
@@ -283,6 +283,7 @@ public class DataManager implements Listener {
         private final String source = RedisBungee.getApi().getServerId();
         private final Action action; // for future use!
         private final T payload;
+
         enum Action {
             JOIN,
             LEAVE,
@@ -299,6 +300,7 @@ public class DataManager implements Listener {
     @Getter
     @RequiredArgsConstructor
     static class ServerChangePayload {
+        private final String formerServer;
         private final String server;
     }
 

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -90,7 +90,7 @@ public class RedisBungeeListener implements Listener {
                 jedis.hset("player:" + event.getPlayer().getUniqueId().toString(), "server", event.getServer().getInfo().getName());
                 jedis.publish("redisbungee-data", RedisBungee.getGson().toJson(new DataManager.DataManagerMessage<>(
                         event.getPlayer().getUniqueId(), DataManager.DataManagerMessage.Action.SERVER_CHANGE,
-                        new DataManager.ServerChangePayload(event.getServer().getInfo().getName()))));
+                        new DataManager.ServerChangePayload(event.getPlayer().getServer().getInfo().getName(), event.getServer().getInfo().getName()))));
                 return null;
             }
         });

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerChangedServerNetworkEvent.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerChangedServerNetworkEvent.java
@@ -6,6 +6,8 @@
  */
 package com.imaginarycode.minecraft.redisbungee.events;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.md_5.bungee.api.plugin.Event;
 
@@ -14,27 +16,17 @@ import java.util.UUID;
 /**
  * This event is sent when a player connects to a new server. RedisBungee sends the event only when
  * the proxy the player has been connected to is different than the local proxy.
- * <p>
+ * <p/>
  * This event corresponds to {@link net.md_5.bungee.api.event.ServerConnectedEvent}, and is fired
  * asynchronously.
  *
  * @since 0.3.4
  */
 @ToString
+@Getter
+@RequiredArgsConstructor
 public class PlayerChangedServerNetworkEvent extends Event {
     private final UUID uuid;
+    private final String formerServer;
     private final String server;
-
-    public PlayerChangedServerNetworkEvent(UUID uuid, String server) {
-        this.uuid = uuid;
-        this.server = server;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
-
-    public String getServer() {
-        return server;
-    }
 }

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerJoinedNetworkEvent.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerJoinedNetworkEvent.java
@@ -6,6 +6,8 @@
  */
 package com.imaginarycode.minecraft.redisbungee.events;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.md_5.bungee.api.plugin.Event;
 
@@ -14,21 +16,15 @@ import java.util.UUID;
 /**
  * This event is sent when a player joins the network. RedisBungee sends the event only when
  * the proxy the player has been connected to is different than the local proxy.
- * <p>
+ * <p/>
  * This event corresponds to {@link net.md_5.bungee.api.event.PostLoginEvent}, and is fired
  * asynchronously.
  *
  * @since 0.3.4
  */
 @ToString
+@Getter
+@RequiredArgsConstructor
 public class PlayerJoinedNetworkEvent extends Event {
     private final UUID uuid;
-
-    public PlayerJoinedNetworkEvent(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
 }

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerLeftNetworkEvent.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PlayerLeftNetworkEvent.java
@@ -6,6 +6,8 @@
  */
 package com.imaginarycode.minecraft.redisbungee.events;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.md_5.bungee.api.plugin.Event;
 
@@ -14,21 +16,15 @@ import java.util.UUID;
 /**
  * This event is sent when a player disconnects. RedisBungee sends the event only when
  * the proxy the player has been connected to is different than the local proxy.
- * <p>
+ * <p/>
  * This event corresponds to {@link net.md_5.bungee.api.event.PlayerDisconnectEvent}, and is fired
  * asynchronously.
  *
  * @since 0.3.4
  */
 @ToString
+@Getter
+@RequiredArgsConstructor
 public class PlayerLeftNetworkEvent extends Event {
     private final UUID uuid;
-
-    public PlayerLeftNetworkEvent(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
 }

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PubSubMessageEvent.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/events/PubSubMessageEvent.java
@@ -6,28 +6,22 @@
  */
 package com.imaginarycode.minecraft.redisbungee.events;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.md_5.bungee.api.plugin.Event;
 
 /**
  * This event is posted when a PubSub message is received.
- * <p>
+ * <p/>
  * <strong>Warning</strong>: This event is fired in a separate thread!
  *
  * @since 0.2.6
  */
 @RequiredArgsConstructor
 @ToString
+@Getter
 public class PubSubMessageEvent extends Event {
     private final String channel;
     private final String message;
-
-    public String getChannel() {
-        return channel;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 }


### PR DESCRIPTION
I updated version to 0.3.6, but I think this is not backward compatible, (and so should be 0.4).
