### PR TITLE
Added network-id configuration option

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -113,7 +113,7 @@ public final class RedisBungee extends Plugin {
                 nagAboutServers.set(10);
             }
             ImmutableList.Builder<String> servers = ImmutableList.builder();
-            Map<String, String> heartbeats = jedis.hgetAll("heartbeats");
+            Map<String, String> heartbeats = jedis.hgetAll("heartbeats:" + configuration.getNetworkId());
             for (Map.Entry<String, String> entry : heartbeats.entrySet()) {
                 try {
                     long stamp = Long.parseLong(entry.getValue());
@@ -135,7 +135,7 @@ public final class RedisBungee extends Plugin {
     public Set<UUID> getPlayersOnProxy(String server) {
         checkArgument(getServerIds().contains(server), server + " is not a valid proxy ID");
         try (Jedis jedis = pool.getResource()) {
-            Set<String> users = jedis.smembers("proxy:" + server + ":usersOnline");
+            Set<String> users = jedis.smembers("proxy:" + configuration.getNetworkId() + ":" + server + ":usersOnline");
             ImmutableSet.Builder<UUID> builder = ImmutableSet.builder();
             for (String user : users) {
                 builder.add(UUID.fromString(user));
@@ -181,7 +181,7 @@ public final class RedisBungee extends Plugin {
         if (pool != null) {
             try (Jedis rsc = pool.getResource()) {
                 for (String i : getServerIds()) {
-                    c += rsc.scard("proxy:" + i + ":usersOnline");
+                    c += rsc.scard("proxy:" + configuration.getNetworkId() + ":" + i + ":usersOnline");
                 }
             } catch (JedisConnectionException e) {
                 // Redis server has disappeared!
@@ -206,7 +206,7 @@ public final class RedisBungee extends Plugin {
             try (Jedis rsc = pool.getResource()) {
                 List<String> keys = new ArrayList<>();
                 for (String i : getServerIds()) {
-                    keys.add("proxy:" + i + ":usersOnline");
+                    keys.add("proxy:" + configuration.getNetworkId() + ":" + i + ":usersOnline");
                 }
                 if (!keys.isEmpty()) {
                     Set<String> users = rsc.sunion(keys.toArray(new String[keys.size()]));
@@ -259,7 +259,7 @@ public final class RedisBungee extends Plugin {
         }
         if (pool != null) {
             try (Jedis tmpRsc = pool.getResource()) {
-                tmpRsc.hset("heartbeats", configuration.getServerId(), String.valueOf(System.currentTimeMillis()));
+                tmpRsc.hset("heartbeats:" + configuration.getNetworkId(), configuration.getServerId(), String.valueOf(System.currentTimeMillis()));
                 // This is more portable than INFO <section>
                 String info = tmpRsc.info();
                 for (String s : info.split("\r\n")) {
@@ -288,7 +288,7 @@ public final class RedisBungee extends Plugin {
                 @Override
                 public void run() {
                     try (Jedis rsc = pool.getResource()) {
-                        rsc.hset("heartbeats", configuration.getServerId(), String.valueOf(System.currentTimeMillis()));
+                        rsc.hset("heartbeats:" + configuration.getNetworkId(), configuration.getServerId(), String.valueOf(System.currentTimeMillis()));
                     } catch (JedisConnectionException e) {
                         // Redis server has disappeared!
                         getLogger().log(Level.SEVERE, "Unable to update heartbeat - did your Redis server go away?", e);
@@ -318,7 +318,7 @@ public final class RedisBungee extends Plugin {
                 public void run() {
                     try (Jedis tmpRsc = pool.getResource()) {
                         Set<String> players = getLocalPlayersAsUuidStrings();
-                        Set<String> redisCollection = tmpRsc.smembers("proxy:" + configuration.getServerId() + ":usersOnline");
+                        Set<String> redisCollection = tmpRsc.smembers("proxy:" + configuration.getNetworkId() + ":" + configuration.getServerId() + ":usersOnline");
 
                         for (String member : redisCollection) {
                             if (!players.contains(member)) {
@@ -326,7 +326,7 @@ public final class RedisBungee extends Plugin {
                                 boolean found = false;
                                 for (String proxyId : getServerIds()) {
                                     if (proxyId.equals(configuration.getServerId())) continue;
-                                    if (tmpRsc.sismember("proxy:" + proxyId + ":usersOnline", member)) {
+                                    if (tmpRsc.sismember("proxy:" + configuration.getNetworkId() + ":" + proxyId + ":usersOnline", member)) {
                                         // Just clean up the set.
                                         found = true;
                                         break;
@@ -336,7 +336,7 @@ public final class RedisBungee extends Plugin {
                                     RedisUtil.cleanUpPlayer(member, tmpRsc);
                                     getLogger().warning("Player found in set that was not found locally and globally: " + member);
                                 } else {
-                                    tmpRsc.srem("proxy:" + configuration.getServerId() + ":usersOnline", member);
+                                    tmpRsc.srem("proxy:" + configuration.getNetworkId() + ":" + configuration.getServerId() + ":usersOnline", member);
                                     getLogger().warning("Player found in set that was not found locally, but is on another proxy: " + member);
                                 }
                             }
@@ -348,7 +348,7 @@ public final class RedisBungee extends Plugin {
 
                             // Player not online according to Redis but not BungeeCord.
                             getLogger().warning("Player " + player + " is on the proxy but not in Redis.");
-                            tmpRsc.sadd("proxy:" + configuration.getServerId() + ":usersOnline", player);
+                            tmpRsc.sadd("proxy:" + configuration.getNetworkId() + ":" + configuration.getServerId() + ":usersOnline", player);
                         }
                     }
                 }
@@ -368,9 +368,9 @@ public final class RedisBungee extends Plugin {
             getProxy().getPluginManager().unregisterListeners(this);
 
             try (Jedis tmpRsc = pool.getResource()) {
-                tmpRsc.hdel("heartbeats", configuration.getServerId());
-                if (tmpRsc.scard("proxy:" + configuration.getServerId() + ":usersOnline") > 0) {
-                    Set<String> players = tmpRsc.smembers("proxy:" + configuration.getServerId() + ":usersOnline");
+                tmpRsc.hdel("heartbeats:" + configuration.getNetworkId(), configuration.getServerId());
+                if (tmpRsc.scard("proxy:" + configuration.getNetworkId() + ":" + configuration.getServerId() + ":usersOnline") > 0) {
+                    Set<String> players = tmpRsc.smembers("proxy:" + configuration.getNetworkId() + ":" + configuration.getServerId() + ":usersOnline");
                     for (String member : players)
                         RedisUtil.cleanUpPlayer(member, tmpRsc);
                 }

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeAPI.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeAPI.java
@@ -220,6 +220,16 @@ public class RedisBungeeAPI {
     }
 
     /**
+     * Get the current BungeeCord network ID for this network.
+     *
+     * @return the current network ID
+     * @since 0.2.5
+     */
+    public final String getNetworkId() {
+        return RedisBungee.getConfiguration().getNetworkId();
+    }
+
+    /**
      * Get the current BungeeCord server ID for this server.
      *
      * @return the current server ID

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeConfiguration.java
@@ -39,6 +39,8 @@ public class RedisBungeeConfiguration {
     @Getter
     private final JedisPool pool;
     @Getter
+    private final String networkId;
+    @Getter
     private final String serverId;
     @Getter
     private final boolean registerBungeeCommands;
@@ -47,6 +49,7 @@ public class RedisBungeeConfiguration {
 
     public RedisBungeeConfiguration(JedisPool pool, Configuration configuration) {
         this.pool = pool;
+        this.networkId = configuration.getString("network-id");
         this.serverId = configuration.getString("server-id");
         this.registerBungeeCommands = configuration.getBoolean("register-bungee-commands", true);
 

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -107,10 +107,11 @@ public class RedisBungeeListener implements Listener {
                 Map<String, String> playerData = new HashMap<>(4);
                 playerData.put("online", "0");
                 playerData.put("ip", event.getConnection().getAddress().getAddress().getHostAddress());
+                playerData.put("network", RedisBungee.getConfiguration().getNetworkId());
                 playerData.put("proxy", RedisBungee.getConfiguration().getServerId());
 
                 Pipeline pipeline = jedis.pipelined();
-                pipeline.sadd("proxy:" + RedisBungee.getApi().getServerId() + ":usersOnline", event.getConnection().getUniqueId().toString());
+                pipeline.sadd("proxy:" + RedisBungee.getApi().getNetworkId() + ":" + RedisBungee.getApi().getServerId() + ":usersOnline", event.getConnection().getUniqueId().toString());
                 plugin.getUuidTranslator().persistInfo(event.getConnection().getName(), event.getConnection().getUniqueId(), pipeline);
                 pipeline.hmset("player:" + event.getConnection().getUniqueId().toString(), playerData);
                 // We're not publishing, the API says we only publish at PostLoginEvent time.

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisUtil.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisUtil.java
@@ -37,16 +37,18 @@ import redis.clients.jedis.Pipeline;
 public class RedisUtil {
     // Compatibility restraints prevent me from using using HDEL with multiple keys.
     public static void cleanUpPlayer(String player, Jedis rsc) {
-        rsc.srem("proxy:" + RedisBungee.getApi().getServerId() + ":usersOnline", player);
+        rsc.srem("proxy:" + RedisBungee.getApi().getNetworkId() + ":" + RedisBungee.getApi().getServerId() + ":usersOnline", player);
         rsc.hdel("player:" + player, "server");
         rsc.hdel("player:" + player, "ip");
+        rsc.hdel("player:" + player, "network");
         rsc.hdel("player:" + player, "proxy");
     }
 
     public static void cleanUpPlayer(String player, Pipeline rsc) {
-        rsc.srem("proxy:" + RedisBungee.getApi().getServerId() + ":usersOnline", player);
+        rsc.srem("proxy:" + RedisBungee.getApi().getNetworkId() + ":" + RedisBungee.getApi().getServerId() + ":usersOnline", player);
         rsc.hdel("player:" + player, "server");
         rsc.hdel("player:" + player, "ip");
+        rsc.hdel("player:" + player, "network");
         rsc.hdel("player:" + player, "proxy");
     }
 

--- a/src/main/resources/example_config.yml
+++ b/src/main/resources/example_config.yml
@@ -12,6 +12,9 @@ redis-password: ""
 # inefficient plugins or a lot of players.
 max-redis-connections: 8
 
+# Which BungeeCord network this instance belongs too.
+network-id: test
+
 # An identifier for this BungeeCord instance.
 server-id: test1
 


### PR DESCRIPTION
Adds a 'network-id' configuration option that allows multiple RedisBungee setups to use the same Redis server. Biggest use case would be for separation of production and dev/test networks.