### PR TITLE
fix automatic pubsub reconnect in case of network issues

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -519,7 +519,14 @@ public final class RedisBungee extends Plugin {
                     // FIXME: Extremely ugly hack
                     // Attempt to unsubscribe this instance and try again.
                     getLogger().log(Level.INFO, "PubSub error, attempting to recover.", e);
-                    jpsh.unsubscribe();
+                    try {
+                        jpsh.unsubscribe();
+                    } catch (Exception e1) {
+                        /* This may fail with
+                        - java.net.SocketException: Broken pipe
+                        - redis.clients.jedis.exceptions.JedisConnectionException: JedisPubSub was not subscribed to a Jedis instance
+                        */
+                    }
                     broken = true;
                 }
             }


### PR DESCRIPTION
Happened to us during a network separation, resulting in not longer listeing to network events

```
redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Broken pipe
    at redis.clients.jedis.Connection.flush(Connection.java:291)
    at redis.clients.jedis.JedisPubSub.unsubscribe(JedisPubSub.java:44)
    at com.imaginarycode.minecraft.redisbungee.RedisBungee$PubSubListener.run(RedisBungee.java:526)
    at net.md_5.bungee.scheduler.BungeeTask.run(BungeeTask.java:63)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.SocketException: Broken pipe
    at java.net.SocketOutputStream.socketWrite0(Native Method)
    at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:109)
    at java.net.SocketOutputStream.write(SocketOutputStream.java:153)
    at redis.clients.util.RedisOutputStream.flushBuffer(RedisOutputStream.java:31)
    at redis.clients.util.RedisOutputStream.flush(RedisOutputStream.java:213)
    at redis.clients.jedis.Connection.flush(Connection.java:288)
    ... 6 more
```