### PR TITLE
Fix unknown class bug in Apache Commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.3</version>
+            <version>2.4.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The version of Apache Commons Pool listed under the dependencies has a well known ClassLoader bug (can be seen on their issue tracker) under some systems. The latest version of this dependency fixes the issue and has no side effects on RedisBungee.