### PR TITLE
improved ability to recover pubsub

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -528,23 +528,22 @@ public final class RedisBungee extends Plugin {
                     broken = true;
                 }
             }catch (JedisConnectionException e) {
-            	getLogger().log(Level.INFO, "PubSub error, attempting to recover in 5 secs.");
-            	getProxy().getScheduler().schedule(RedisBungee.this, PubSubListener.this, 5, TimeUnit.SECONDS);
-            	
-			}
+                getLogger().log(Level.INFO, "PubSub error, attempting to recover in 5 secs.");
+                getProxy().getScheduler().schedule(RedisBungee.this, PubSubListener.this, 5, TimeUnit.SECONDS);
+            }
 
             if (broken) {
-                run();                
+                run();
             }
         }
 
         public void addChannel(String... channel) {
-        	addedChannels.addAll(Arrays.asList(channel));
+            addedChannels.addAll(Arrays.asList(channel));
             jpsh.subscribe(channel);            
         }
 
         public void removeChannel(String... channel) {
-        	addedChannels.removeAll(Arrays.asList(channel));
+            addedChannels.removeAll(Arrays.asList(channel));
             jpsh.unsubscribe(channel);
         }
 


### PR DESCRIPTION
When the redis server goes down RedisBungee doesn't always subscribe to previously registered channels again.

This PR tries to subscribe to channels again, if it didn't work before. It also makes sure that all channels registered by plugins are subscribed to again.

I restarted the redis server multiple times in our production environment and it always seemed to reconnect and resubscribe to the relevant channels. However this is the only case I tested properly. I could imagine that this causes some spam, if you didn't configure RedisBungee correctly.