### PR TITLE
Fixing registerChannel issue in 1.14.2

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -368,7 +368,7 @@ public final class RedisBungee extends Plugin {
                 }
             }, 0, 1, TimeUnit.MINUTES);
         }
-        getProxy().registerChannel("legacy:RedisBungee");
+        getProxy().registerChannel("legacy:redisbungee");
         getProxy().registerChannel("RedisBungee");
     }
 


### PR DESCRIPTION
1.14.2 seems to require registerChannel in all lowercase.
[23:17:02] [Server thread/ERROR]: Couldn't register custom payload
java.lang.IllegalArgumentException: Channel must be entirely lowercase (attempted to use legacy:RedisBungee)