### PR TITLE
changed plugin channel to lowercase (fix #67)

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -148,7 +148,7 @@ public class RedisBungeeListener implements Listener {
 
     @EventHandler
     public void onPluginMessage(final PluginMessageEvent event) {
-        if ((event.getTag().equals("legacy:RedisBungee") || event.getTag().equals("RedisBungee")) && event.getSender() instanceof Server) {
+        if ((event.getTag().equals("legacy:redisbungee") || event.getTag().equals("RedisBungee")) && event.getSender() instanceof Server) {
             final String currentChannel = event.getTag();
             final byte[] data = Arrays.copyOf(event.getData(), event.getData().length);
             plugin.getProxy().getScheduler().runAsync(plugin, new Runnable() {


### PR DESCRIPTION
#67 changed the capitalization of the plugin channel to work with 1.14.2.

This PR adjusts the capitalization in another class, that the original pr missed.

This might be the cause for the spigot review https://www.spigotmc.org/resources/redisbungee.13494/reviews#review-281998-172302 by luffy1025.