### PR TITLE
Allow the replacement of BungeeCord thread pool to fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.16</version>
+            <version>1.18.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -223,14 +223,15 @@ public final class RedisBungee extends Plugin {
     @Override
     public void onEnable() {
         ThreadFactory factory = ((ThreadPoolExecutor) getExecutorService()).getThreadFactory();
-        getExecutorService().shutdownNow();
-        ScheduledExecutorService service;
+        ScheduledExecutorService service = Executors.newScheduledThreadPool(24, factory);
         try {
             Field field = Plugin.class.getDeclaredField("service");
             field.setAccessible(true);
-            field.set(this, service = Executors.newScheduledThreadPool(24, factory));
+            ExecutorService builtinService = (ExecutorService) field.get(this);
+            field.set(this, service);
+            builtinService.shutdownNow();
         } catch (Exception e) {
-            throw new RuntimeException("Can't replace BungeeCord thread pool with our own", e);
+            getLogger().log(Level.WARNING, "Can't replace BungeeCord thread pool with our own", e);
         }
         try {
             loadConfig();


### PR DESCRIPTION
Some BungeeCord forks have different implementation details and RedisBungee won't load